### PR TITLE
Fix Windows build architecture configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,10 @@
       "icon": "assets/icon.icns"
     },
     "win": {
-      "target": "nsis",
+      "target": {
+        "target": "nsis",
+        "arch": ["x64"]
+      },
       "icon": "assets/icon.ico"
     },
     "nsis": {


### PR DESCRIPTION
## Summary
- Fix electron-builder Windows target to explicitly build for x64 architecture
- Resolves "이 앱을 실행할 수 없습니다" error on 64-bit Windows systems
- Change win.target from string to object with arch specification

## Problem
When building with `pnpm dist:win`, the generated exe file shows "현재 PC에서는 이 앱을 실행할 수 없습니다" error on Windows systems. This was caused by electron-builder defaulting to 32-bit (ia32) architecture when no explicit architecture is specified.

## Solution
Updated package.json build configuration:
```json
"win": {
  "target": {
    "target": "nsis",
    "arch": ["x64"]
  },
  "icon": "assets/icon.ico"
}
```

## Test plan
- [x] Build Windows installer with `pnpm dist:win`
- [x] Verify generated installer is for x64 architecture
- [ ] Test installation and execution on 64-bit Windows system

🤖 Generated with [Claude Code](https://claude.ai/code)