### PR TITLE
Fix NSIS installer configuration to prevent process conflicts

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,11 @@
     },
     "nsis": {
       "oneClick": false,
-      "allowToChangeInstallationDirectory": true
+      "allowToChangeInstallationDirectory": true,
+      "createDesktopShortcut": true,
+      "createStartMenuShortcut": true,
+      "allowElevation": true,
+      "runAfterFinish": false
     }
   }
 }


### PR DESCRIPTION
## Summary
- Improve NSIS installer configuration to resolve installation conflicts
- Prevent "Shopping Mall Tax Calculator cannot be closed" error during installation
- Add proper installer permissions and user-friendly options

## Problem
During installation, users encounter an error message stating "Shopping Mall Tax Calculator cannot be closed. Please close it manually and click Retry to continue." This occurs even when no visible processes are running, causing installation failures.

## Solution
Enhanced NSIS configuration in package.json:

### Key Changes
```json
"nsis": {
  "oneClick": false,
  "allowToChangeInstallationDirectory": true,
  "createDesktopShortcut": true,
  "createStartMenuShortcut": true,
  "allowElevation": true,
  "runAfterFinish": false
}
```

### Benefits
- **runAfterFinish: false** - Prevents automatic app launch after installation, eliminating process conflicts
- **allowElevation: true** - Enables proper installer permissions for system-level installation
- **createDesktopShortcut/createStartMenuShortcut** - Improves user experience with convenient shortcuts
- **Better installer flow** - Reduces installation friction and error rates

## Test plan
- [x] Build Windows installer with `pnpm dist:win`
- [x] Verify NSIS configuration is properly applied
- [ ] Test installation on clean Windows system
- [ ] Verify no process conflict errors occur
- [ ] Confirm shortcuts are created properly

## Additional Troubleshooting
For cases where the error persists, users can:
1. Use PowerShell to force-kill any hidden processes
2. Clear temporary installation files
3. Use Resource Monitor to check file handles
4. Restart system if needed

🤖 Generated with [Claude Code](https://claude.ai/code)