### PR TITLE
fix: Reset multi-column checkbox state when switching processing modes

### DIFF
--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -59,6 +59,12 @@ class TaxCalculatorApp {
     const taxTypeOptions = document.getElementById('taxTypeOptions');
     const taxTypeConfig = document.getElementById('taxTypeConfig');
     
+    // Reset multi-column checkbox and UI when switching modes
+    const multiColumnCheckbox = document.getElementById('useMultiColumnSum') as HTMLInputElement;
+    const multiColumnConfig = document.getElementById('multiColumnConfig');
+    const amountColumn = document.getElementById('amountColumn') as HTMLSelectElement;
+    const amountColumnGroup = amountColumn?.closest('.option-group') as HTMLElement;
+    
     if (taxTypeMode?.checked) {
       traditionalOptions!.style.display = 'none';
       taxTypeOptions!.style.display = 'grid';
@@ -67,6 +73,17 @@ class TaxCalculatorApp {
       traditionalOptions!.style.display = 'grid';
       taxTypeOptions!.style.display = 'none';
       taxTypeConfig!.style.display = 'none';
+      
+      // Reset multi-column state when switching to traditional mode
+      if (multiColumnCheckbox) {
+        multiColumnCheckbox.checked = false;
+      }
+      if (multiColumnConfig) {
+        multiColumnConfig.style.display = 'none';
+      }
+      if (amountColumnGroup) {
+        amountColumnGroup.style.display = 'flex';
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
Fixed UI bug where multi-column selection area remained visible after switching processing modes

## Problem
When users:
1. Select "과세유형별 분류 방식" (Tax type classification mode)
2. Check "다중 컬럼 합계 사용" (Use multi-column sum) checkbox
3. Switch back to "기존 방식" (Traditional mode)

The multi-column selection area remained visible even though it's not applicable to traditional mode.

## Solution
Modified `toggleProcessingMode()` function to:
- Reset the multi-column checkbox to unchecked state
- Hide the multi-column selection area
- Show the single amount column selection

## Test plan
- [x] Check multi-column checkbox in tax type mode
- [x] Switch to traditional mode and verify:
  - Multi-column checkbox is unchecked
  - Multi-column selection area is hidden
  - Single amount column selection is visible
- [x] Switch back to tax type mode and verify normal operation

🤖 Generated with [Claude Code](https://claude.ai/code)